### PR TITLE
Improve macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,15 @@ This repository builds a minimal Game Boy Advance ROM using C and Ninja.
 
 Run `ninja` to produce `hello.gba`. The build uses Clang for compilation and
 `ld.lld` for linking to target the `armv4t-none-eabi` architecture. It requires
-`llvm-objcopy-19` and a recent `lld`.
+`llvm-objcopy` (version 19 on Linux) and `lld`.
 
 ### macOS
 
-On macOS the system `clang` does not ship with `lld`. Install the `llvm`
-formula from Homebrew and ensure `ld.lld` is in your `PATH`:
+On macOS the system `clang` does not ship with `lld`. Install the `llvm` and
+`lld` formulas from Homebrew:
 
 ```sh
-brew install llvm
-export PATH="$(brew --prefix llvm)/bin:$PATH"
+brew install llvm lld
 ```
-
-After this, running `ninja` should succeed.
+The build script automatically searches Homebrew's directories, so no further
+setup is required. After this, running `ninja` should succeed.

--- a/build.ninja
+++ b/build.ninja
@@ -1,15 +1,16 @@
+brewpaths = /opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin
 cflags = -target armv4t-none-eabi -march=armv4t -nostdlib -ffreestanding -Wall -O2
 # Use LLD directly when linking so that Apple's clang can be used on macOS.
 ldflags = -T linker.ld -m armelf
 
 rule cc
-  command = clang $cflags -c $in -o $out
+  command = PATH=$brewpaths:$$PATH clang $cflags -c $in -o $out
 
 rule link
-  command = ld.lld $ldflags $in -o $out
+  command = PATH=$brewpaths:$$PATH ld.lld $ldflags $in -o $out
 
 rule objcopy
-  command = llvm-objcopy-19 -O binary $in $out
+  command = PATH=$brewpaths:$$PATH ./objcopy.sh -O binary $in $out
 
 build build/crt0.o: cc src/crt0.s
 build build/main.o: cc src/main.c

--- a/objcopy.sh
+++ b/objcopy.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+if command -v llvm-objcopy-19 >/dev/null 2>&1; then
+  exec llvm-objcopy-19 "$@"
+elif command -v llvm-objcopy >/dev/null 2>&1; then
+  exec llvm-objcopy "$@"
+else
+  echo "llvm-objcopy not found" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- link with `ld.lld` instead of using `clang -fuse-ld=lld`
- document how to install Homebrew LLVM for macOS users

## Testing
- `ninja -v`

------
https://chatgpt.com/codex/tasks/task_e_6859f8e6311c8326b2da4e5431bb9e7a