### PR TITLE
Fix build without llvm-objcopy

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -13,11 +13,11 @@ rule compile
 rule link
   command = PATH=$path ld.lld -T linker.ld -m armelf $in -o $out
 
-rule objcopy
-  command = PATH=$path llvm-objcopy -O binary $in $out
+rule binary
+  command = PATH=$path ld.lld -T linker.ld -m armelf $in --oformat=binary -o $out
 
 build out/main.o:    compile  src/main.c
 build out/crt0.o:    assemble src/crt0.s
 build out/gba_header.o: assemble src/gba_header.s
 build out/hello.elf: link     out/gba_header.o out/main.o out/crt0.o
-build hello.gba:     objcopy  out/hello.elf
+build hello.gba:     binary   out/gba_header.o out/main.o out/crt0.o


### PR DESCRIPTION
## Summary
- remove dependency on `llvm-objcopy`
- use `ld.lld --oformat=binary` to produce `hello.gba`

## Testing
- `ninja`


------
https://chatgpt.com/codex/tasks/task_e_685a025417f883269f78613c8628dd8c