### PR TITLE
Fix header alignment for hello.gba

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -7,6 +7,9 @@ SECTIONS {
     .text : {
         *(.text*)
     }
+    .ARM.exidx : {
+        *(.ARM.exidx*)
+    }
     .rodata : {
         *(.rodata*)
     }


### PR DESCRIPTION
## Summary
- fix the linker script so the ARM exidx section appears after the ROM header

## Testing
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_685a03c0bae08326a14e7cbd2a50ff30