### PR TITLE
Add stack symbols and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@ This repository builds a simple Game Boy Advance ROM that displays a ball bounci
 
 Run `ninja` to produce `hello.gba`.
 On Mac first `brew install llvm lld`.
+
+## Stack Setup
+
+The linker script defines three symbols related to the stack:
+
+```
+__stack_top    = 0x03007FE0;
+__stack_size   = 0x1000;    # 4 KiB stack
+__stack_bottom = __stack_top - __stack_size;
+```
+
+`crt0.s` initializes `sp` with `__stack_top`. Adjust `__stack_size` in
+`src/linker.ld` to change the reserved stack space. A linker assertion warns if
+the `.bss` section ever grows beyond `__stack_bottom`.

--- a/src/crt0.s
+++ b/src/crt0.s
@@ -1,7 +1,7 @@
     .section .text
     .global _start
 _start:
-    ldr sp, =0x03007FE0
+    ldr sp, =__stack_top
     ldr r0, =main
     bx  r0
 1:  b 1b

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -16,7 +16,16 @@ SECTIONS {
     .data : {
         *(.data*)
     }
+
+    . = 0x03000000;
     .bss : {
+        __bss_start = .;
         *(.bss*)
+        __bss_end = .;
     }
+    __stack_top = 0x03007FE0;
+    __stack_size = 0x1000;
+    __stack_bottom = __stack_top - __stack_size;
+    /* Ensure there is room for the stack below .bss */
+    ASSERT(__bss_end <= __stack_bottom, ".bss overlaps stack")
 }


### PR DESCRIPTION
## Summary
- define `__stack_top`, `__stack_size`, and `__stack_bottom` in `linker.ld`
- place `.bss` in IWRAM and assert it doesn't collide with the stack
- initialize `sp` using `__stack_top` in `crt0.s`
- document the stack symbols in the README

## Testing
- `ninja -t clean`
- `ninja`


------
https://chatgpt.com/codex/tasks/task_e_685b223c81ac83269a089d13cbacde17