### PR TITLE
Use built‑in _Accum type

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -10,7 +10,7 @@ rule assemble
   command = PATH=$path $cc $arch -c $in -o $out
 
 rule compile
-  command = PATH=$path $cc $arch -c $in -o $out -Os -ffreestanding -Werror $warn -fcolor-diagnostics
+  command = PATH=$path $cc $arch -c $in -o $out -Os -ffreestanding -Werror $warn -fcolor-diagnostics -ffixed-point
 
 rule link
   command = PATH=$path $ld -T src/linker.ld --oformat=binary $in -o $out


### PR DESCRIPTION
## Summary
- enable the C fixed-point extension in the build
- use `_Accum` instead of the integer `fixed` type
- adjust velocity math to avoid runtime division

## Testing
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_685bcd8b271c83268afb597de2c44956