### PR TITLE
Implement __aeabi_memcpy

### DIFF
--- a/src/crt0.s
+++ b/src/crt0.s
@@ -5,3 +5,18 @@ _start:
     ldr r0, =main
     bx  r0
 1:  b 1b
+
+    .thumb_func
+    .global __aeabi_memcpy
+__aeabi_memcpy:
+    cmp r2, #0
+    beq 2f
+1:
+    ldrb r3, [r1]
+    adds r1, #1
+    strb r3, [r0]
+    adds r0, #1
+    subs r2, #1
+    bne 1b
+2:
+    bx lr


### PR DESCRIPTION
## Summary
- implement `__aeabi_memcpy` in `crt0.s` for ARMv4T builds

## Testing
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_685e28131368832691ebae773138282e