### PR TITLE
Randomize fireworks velocities

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -294,9 +294,9 @@ void main(void) {
                 _Accum const scale = s / 32768.0K;
                 for (int i = 0; i < len(stars); i++) {
                     rng = rand_lcg(rng);
-                    stars[i].vx = (int16_t)(rng >> 16) * scale;
+                    stars[i].vx = ((int32_t)rng >> 16) * scale;
                     rng = rand_lcg(rng);
-                    stars[i].vy = (int16_t)(rng >> 16) * scale;
+                    stars[i].vy = ((int32_t)rng >> 16) * scale;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- seed LCG with frame count when deciding a winner
- choose random velocity in [-0.75K, 0.75K] for each star

## Testing
- `ninja -v`


------
https://chatgpt.com/codex/tasks/task_e_685e3748949c8326ae37d2702ec126fc